### PR TITLE
Chore: Add quotes in template

### DIFF
--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -172,7 +172,7 @@ bcmath.scale = 0
 
 [Session]
 session.save_handler = {{ php_session_save_handler }}
-session.save_path = {{ php_session_save_path }}
+session.save_path = "{{ php_session_save_path }}"
 session.use_cookies = 1
 session.use_only_cookies = 1
 session.name = PHPSESSID


### PR DESCRIPTION
We need add quotes to avoid syntax error 
`PHP:  syntax error, unexpected '=' in /etc/php.ini on line 175`